### PR TITLE
Remove explicit jQuery dependency in directive

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -34,7 +34,7 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                     var properties = ['min', 'max', 'step'];
                     // Find out if decimals are to be used for slider
                     var useDecimals = (!angular.isUndefined($attrs.useDecimals)) ? true : false;
-                    $.each(properties, function(i, property){
+                    angular.forEach(properties, function(property, i){
                         // support {{}} and watch for updates
                         $attrs.$observe(property, function(newVal){
                             if (!!newVal) {


### PR DESCRIPTION
We have an app with mixed Angular and legacy code; the `$` global isn't a reference to jQuery, so this line breaks in our app. I've replaced it with a call to `angular.forEach` (and swapped the callback signature, per the difference between the two methods).
