### PR TITLE
fix TypeError: Cannot read property 'length' of undefined, because the v...

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -51,7 +51,9 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                     // Watch ui-slider (byVal) for changes and update
                     scope.$watch(attrs.uiSlider, function(newVal){
                         init();
-                        elm.slider('option', newVal);
+                        if(newVal != undefined) {
+                            elm.slider('option', newVal);
+                        }
                     }, true);
                     
                     // Late-bind to prevent compiler clobbering


### PR DESCRIPTION
scope.$watch(attrs.uiSlider, function(newVal){
  init();
  elm.slider('option', newVal);
}, true);

the variable newVal come as undefined 
that cause an error "TypeError: Cannot read property 'length' of undefined" from jQuery
