### PR TITLE
update the option object when options are changed dynamically

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -51,6 +51,7 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                     attrs.$observe(property, function(newVal) {
                         if (!!newVal) {
                             init();
+                            options[property] = parseNumber(newVal, useDecimals);
                             elm.slider('option', property, parseNumber(newVal, useDecimals));
                             ngModel.$render();
                         }


### PR DESCRIPTION
Untill now, the options where not updated, which caused $render to mistakenly change the $viewValue of the ngModel when options.min, options.max or options.step were changed.
