### PR TITLE
Advertise compatibility with Angular 1.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "package.json"
   ],
   "dependencies": {
-    "angular": "~1.0.x",
+    "angular": ">=1.0.x",
     "jquery-ui": "~1.10.x",
     "jquery": ">= 1.9"
   }


### PR DESCRIPTION
This project is compatible with all Angular 1.X versions, and should use a more relaxed dependency declaration to allow it to be used with Angular 1.3
