### PR TITLE
Only set range if range setting is true

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -84,7 +84,7 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                     init();
                     var method = options.range === true ? 'values' : 'value';
                     
-                    if (!options.range && isNaN(ngModel.$viewValue) && !(ngModel.$viewValue instanceof Array)) {
+                    if (options.range !== true && isNaN(ngModel.$viewValue) && !(ngModel.$viewValue instanceof Array)) {
                         ngModel.$viewValue = 0;
                     }
                     else if (options.range && !angular.isDefined(ngModel.$viewValue)) {


### PR DESCRIPTION
If the range option is set to 'min' and the model value is undefined, it should not set the model value to an array.