### PR TITLE
Surrounding slider destroy event with try/catch.

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -129,8 +129,11 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                 }, true);
 
                 function destroy() {
+                  try {
                     elm.slider('destroy');
+                  } catch (err) {}
                 }
+                
                 scope.$on("$destroy", function() {
                     destroy();
                 });


### PR DESCRIPTION
This will allow ui-slider to be used on with ui-bootstraps modals without throwing. The problem happens when the dom is destroyed before the scope. See my comment in issue #41.