### PR TITLE
smarter handling of destroy - corrects for case where it fails when in a ui-modal

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -129,11 +129,13 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                 }, true);
 
                 function destroy() {
-                    elm.slider('destroy');
+                    if (elm.hasClass('ui-slider')) {
+                        elm.slider('destroy');
+                    }
                 }
-                scope.$on("$destroy", function() {
-                    destroy();
-                });
+
+                scope.$on("$destroy", destroy);
+                elm.one('$destroy', destroy);
             };
 
             var postLink = function (scope, element, attrs, ngModel) {


### PR DESCRIPTION
It looks like there may be a couple attempts to fix this already.  I think this should cover the different use cases without errors.

The jquery slider destroy method removes the ui-slider class, so it's pretty easy to just test for that before calling destroy.
```
_destroy: function() {
		this.handles.remove();
		if ( this.range ) {
			this.range.remove();
		}

		this.element
			.removeClass( "ui-slider" +
				" ui-slider-horizontal" +
				" ui-slider-vertical" +
				" ui-widget" +
				" ui-widget-content" +
				" ui-corner-all" );

		this._mouseDestroy();
	},
```

Other issues/pull requests:
https://github.com/angular-ui/ui-slider/issues/41
https://github.com/angular-ui/ui-slider/pull/75