### PR TITLE
Update for issue #83 where the range slider does not update when you type number into the text input. Also found issue with the range mins/max in this circumstance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 components/
 node_modules/
 bower_components/
+demo/double.html

--- a/src/slider.js
+++ b/src/slider.js
@@ -135,7 +135,13 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
 
                     // Do some sanity check of range values
                     if (options.range === true) {
-                        
+                        // previously, the model was a string b/c it was in a text input, need to convert to a array.
+                        // make sure input exists, comma exists once, and it is a string. 
+                        if (ngModel.$viewValue && angular.isString(ngModel.$viewValue) && (ngModel.$viewValue.match(/,/g) || []).length === 1) {
+                            // transform string model into array.
+                            var valueArr = ngModel.$viewValue.split(',');
+                            ngModel.$viewValue = [Number(valueArr[0]), Number(valueArr[1])];
+                        }
                         // Check outer bounds for min and max values
                         if (angular.isDefined(options.min) && options.min > ngModel.$viewValue[0]) {
                             ngModel.$viewValue[0] = options.min;
@@ -148,11 +154,11 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                         if (ngModel.$viewValue[0] > ngModel.$viewValue[1]) {
                             // Min value should be less to equal to max value
                             if (prevRangeValues.min >= ngModel.$viewValue[1]) {
-                                ngModel.$viewValue[0] = prevRangeValues.min;
+                                ngModel.$viewValue[1] = prevRangeValues.min;
                             }
                             // Max value should be less to equal to min value
                             if (prevRangeValues.max <= ngModel.$viewValue[0]) {
-                                ngModel.$viewValue[1] = prevRangeValues.max;
+                                ngModel.$viewValue[0] = prevRangeValues.max;
                             }
                         }
 


### PR DESCRIPTION
The main issue related to this pull request is that the text input field was converting the array into a string, so we need to convert it back to a array when updating the model slider when we have a range.

Related to this, I have noticed other issues where the input fields are not friendly with the slider. For instance another issue occurs with example 14 and 15 with the upper bounds. If you type in a number into the input field, it disregards the bounds. 