### PR TITLE
fix tick definition when min is other than 0

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -125,7 +125,7 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                 ngModel.$render = function() {
                     init();
                     var method = options.range === true ? 'values' : 'value';
-                    
+
                     if (options.range !== true && isNaN(ngModel.$viewValue) && !(ngModel.$viewValue instanceof Array)) {
                         ngModel.$viewValue = 0;
                     }
@@ -136,7 +136,7 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                     // Do some sanity check of range values
                     if (options.range === true) {
                         // previously, the model was a string b/c it was in a text input, need to convert to a array.
-                        // make sure input exists, comma exists once, and it is a string. 
+                        // make sure input exists, comma exists once, and it is a string.
                         if (ngModel.$viewValue && angular.isString(ngModel.$viewValue) && (ngModel.$viewValue.match(/,/g) || []).length === 1) {
                             // transform string model into array.
                             var valueArr = ngModel.$viewValue.split(',');
@@ -190,14 +190,14 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                 // Add tick marks if 'tick' and 'step' attributes have been setted on element.
                 // Support horizontal slider bar so far. 'tick' and 'step' attributes are required.
                 var options = angular.extend({}, scope.$eval(attrs.uiSlider));
-                var properties = ['max', 'step', 'tick'];
+                var properties = ['min', 'max', 'step', 'tick'];
                 angular.forEach(properties, function(property) {
                     if (angular.isDefined(attrs[property])) {
                         options[property] = attrs[property];
                     }
                 });
                 if (angular.isDefined(options['tick']) && angular.isDefined(options['step'])) {
-                    var total = parseInt(parseInt(options['max'])/parseInt(options['step']));
+                    var total = parseInt( (parseInt(options['max']) - parseInt(options['min'])) /parseInt(options['step']));
                     for (var i = total; i >= 0; i--) {
                         var left = ((i / total) * 100) + '%';
                         $("<div/>").addClass("ui-slider-tick").appendTo(element).css({left: left});


### PR DESCRIPTION
The ticks on the slider were always calculated from 0 to max, regardless of the existence of a min value. I fixed that.

Splitting https://github.com/angular-ui/ui-slider/pull/76 in 2 PRs.