### PR TITLE
fix slider tip text in case of range slider

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -175,8 +175,13 @@ angular.module('ui.slider', []).value('uiSliderConfig',{}).directive('uiSlider',
                 scope.$watch(attrs.ngModel, function() {
                     if (options.range === true) {
                         ngModel.$render();
+
+                        $(elm).find('.ui-slider-tip').each(function(i, tipElm) {
+                            $(tipElm).text(ngModel.$viewValue[i]);
+                        });
+                    } else {
+                        $(elm).find('.ui-slider-tip').text(ngModel.$viewValue);
                     }
-                    $(elm).find('.ui-slider-tip').text(ngModel.$viewValue);
                 }, true);
 
                 function destroy() {


### PR DESCRIPTION
**fixed**: when using `data-tip` option with range slider, tip of the unchanged handler displaying whole value (e.g. _0,4_) instead of a single value (e.g. _0_ when the max handler is sliding)